### PR TITLE
fix problem with latex code block

### DIFF
--- a/docs/guide/tools/latex.md
+++ b/docs/guide/tools/latex.md
@@ -50,7 +50,7 @@ To generate a custom LaTeX template, make a copy of the default template, save i
 \newcommandx{\graph}[3][1=,2=]{
     \begin{tikzpicture}
     \begin{axis}[xlabel=$x$,ylabel=$y$, axis lines=center,samples=100, #2]
-    \addplot[#1]{#3};
+    \addplot[#1]{ #3 };
     \end{axis}
     \end{tikzpicture}
 }


### PR DESCRIPTION
Somehow when there is a { followed by # inside a code block, the rest of the code block is ignored. So I added a space to fit it.