### PR TITLE
fix downloadContainer and pin mkdocs-material

### DIFF
--- a/docs/css/buttons.css
+++ b/docs/css/buttons.css
@@ -58,7 +58,7 @@ a.downloadButton:before {
 }
 
 .downloadsContainer {
-    display: grid;
+    display: grid !important;
     justify-content: center;
     text-align: center;
     margin-top: 20px;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material >= 6.1.7
+mkdocs-material == 7.0.4
 mkdocs-macros-plugin >= 0.5.0


### PR DESCRIPTION
Fixes an issue with  buttons not being displayed in a grid that resulted from a newer version of mkdocs-material