### PR TITLE
Update autosave path (preferences.md)

### DIFF
--- a/docs/guide/config/preferences.md
+++ b/docs/guide/config/preferences.md
@@ -5,9 +5,9 @@ Xournal ++ has multiple options that can be configured and customized. Most of t
 
 ## Load / Save
 
-### Autosaving 
+### Autosaving
 
-Enable or disable automatic saving and set the time interval in which it will be done. If the document was previously saved in any folder, the autosave document will be in the same location as a hidden file. Otherwise the file will be saved in the path **~/.xournalpp/autosave**.
+Enable or disable automatic saving and set the time interval in which it will be done. If the document was previously saved in any folder, the autosave document will be in the same location as a hidden file. Otherwise the file will be saved in **$XDG_CACHE_HOME/.xournalpp/autosave** or if not set in **$HOME/.cache/.xournalpp/autosave**. If XDG_CACHE_HOME is not set on Windows systems there are multiple directories possible. Check the [gtk docs](https://docs.gtk.org/glib/func.get_user_cache_dir.html).
 
 ### Default Save Name
 

--- a/docs/guide/config/preferences.md
+++ b/docs/guide/config/preferences.md
@@ -7,7 +7,7 @@ Xournal ++ has multiple options that can be configured and customized. Most of t
 
 ### Autosaving
 
-Enable or disable automatic saving and set the time interval in which it will be done. If the document was previously saved in any folder, the autosave document will be in the same location as a hidden file. Otherwise the file will be saved in **$XDG_CACHE_HOME/.xournalpp/autosaves** or if not set in **$HOME/.cache/.xournalpp/autosaves**. If XDG_CACHE_HOME is not set on Windows systems there are multiple directories possible. Check the [gtk docs](https://docs.gtk.org/glib/func.get_user_cache_dir.html).
+Enable or disable automatic saving and set the time interval in which it will be done. If the document was previously saved in any folder, the autosave document will be in the same location as a hidden file. Otherwise the file will be saved in **$XDG_CACHE_HOME/xournalpp/autosaves** or if not set in **$HOME/.cache/xournalpp/autosaves**. If XDG_CACHE_HOME is not set on Windows systems there are multiple directories possible. Check the [gtk docs](https://docs.gtk.org/glib/func.get_user_cache_dir.html).
 
 ### Default Save Name
 

--- a/docs/guide/config/preferences.md
+++ b/docs/guide/config/preferences.md
@@ -7,7 +7,7 @@ Xournal ++ has multiple options that can be configured and customized. Most of t
 
 ### Autosaving
 
-Enable or disable automatic saving and set the time interval in which it will be done. If the document was previously saved in any folder, the autosave document will be in the same location as a hidden file. Otherwise the file will be saved in **$XDG_CACHE_HOME/.xournalpp/autosave** or if not set in **$HOME/.cache/.xournalpp/autosave**. If XDG_CACHE_HOME is not set on Windows systems there are multiple directories possible. Check the [gtk docs](https://docs.gtk.org/glib/func.get_user_cache_dir.html).
+Enable or disable automatic saving and set the time interval in which it will be done. If the document was previously saved in any folder, the autosave document will be in the same location as a hidden file. Otherwise the file will be saved in **$XDG_CACHE_HOME/.xournalpp/autosaves** or if not set in **$HOME/.cache/.xournalpp/autosaves**. If XDG_CACHE_HOME is not set on Windows systems there are multiple directories possible. Check the [gtk docs](https://docs.gtk.org/glib/func.get_user_cache_dir.html).
 
 ### Default Save Name
 

--- a/docs/guide/config/preferences.md
+++ b/docs/guide/config/preferences.md
@@ -7,13 +7,12 @@ Xournal ++ has multiple options that can be configured and customized. Most of t
 
 ### Autosaving
 
-Enable or disable automatic saving and set the time interval in which it will be done. If the document was previously saved in any folder, the autosave document will be in the same location as a hidden file. Otherwise the file will be saved in **$XDG_CONFIG_HOME/xournalpp/autosave** or if XDG_CONFIG_HOME is not set in **~/.config/xournalpp/autosave**. TODO: Windows
+Enable or disable automatic saving and set the time interval in which it will be done. If the document was previously saved in any folder, the autosave document will be in the same location as a hidden file. Otherwise the file will be saved in your [Config folder](/guide/file-locations#config-folder) in the subfolder `autosave`.
 
 !!! note
 
     The autosave path is about to change in release 1.2.0 and has already been changed in Xournal++ nightly builds.<br>
-    Linux: **$XDG_CACHE_HOME/xournalpp/autosaves** or if XDG_CACHE_HOME is not set **~/.cache/xournalpp/autosaves**.<br>
-    Windows: TODO. See the documentation for [FOLDERID_InternetCache](https://docs.microsoft.com/en-us/windows/win32/shell/knownfolderid#FOLDERID_InternetCache).
+    Autosaves are now in your [Cache folder](/guide/file-locations#cache-folder) in the subfolder `autosaves`.
 
 ### Default Save Name
 

--- a/docs/guide/config/preferences.md
+++ b/docs/guide/config/preferences.md
@@ -7,7 +7,13 @@ Xournal ++ has multiple options that can be configured and customized. Most of t
 
 ### Autosaving
 
-Enable or disable automatic saving and set the time interval in which it will be done. If the document was previously saved in any folder, the autosave document will be in the same location as a hidden file. Otherwise the file will be saved in **$XDG_CACHE_HOME/xournalpp/autosaves** or if not set in **$HOME/.cache/xournalpp/autosaves**. If XDG_CACHE_HOME is not set on Windows systems there are multiple directories possible. Check the [gtk docs](https://docs.gtk.org/glib/func.get_user_cache_dir.html).
+Enable or disable automatic saving and set the time interval in which it will be done. If the document was previously saved in any folder, the autosave document will be in the same location as a hidden file. Otherwise the file will be saved in **$XDG_CONFIG_HOME/xournalpp/autosave** or if XDG_CONFIG_HOME is not set in **~/.config/xournalpp/autosave**. TODO: Windows
+
+!!! note
+
+    The autosave path is about to change in release 1.2.0 and has already been changed in Xournal++ nightly builds.<br>
+    Linux: **$XDG_CACHE_HOME/xournalpp/autosaves** or if XDG_CACHE_HOME is not set **~/.cache/xournalpp/autosaves**.<br>
+    Windows: TODO. See the documentation for [FOLDERID_InternetCache](https://docs.microsoft.com/en-us/windows/win32/shell/knownfolderid#FOLDERID_InternetCache).
 
 ### Default Save Name
 

--- a/docs/guide/file-locations.md
+++ b/docs/guide/file-locations.md
@@ -43,13 +43,15 @@ The localizations folder contains the translations of Xournal++ in all supported
 The config folder contains configuration files like
 
 - the `settings.xml` file, which stores Xournal++ settings
-- `autosave` subfolder for documents that have not been stored previously
 - `metadata` subfolder, which contains metadata of previously opened files
 - the `colornames.ini` file, which allows to configure colors
 
 ## Cache folder
 
-The cache folder contains the `errorlogs` subfolder, which stores crash logs.
+The cache folder contains the following subfolders:
+
+- `errorlogs` which stores crash logs
+- `autosaves` which stores autosaves of new non-saved documents
 
 ## Temporary folder
 


### PR DESCRIPTION
See xournalpp/xournalpp#3587.

As the xournalpp/xournalpp#3587 will get merged to master, how do we make sure that we only merge this PR when xournalpp/xournalpp#3587 is in a release?
Should we add a remark that ~/.config/xournalpp/autosave is deprecated but still used?