### PR TITLE
Add documentation on the PDF tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /site/
 /venv/
+/.venv/
+__pycache__

--- a/docs/css/buttons.css
+++ b/docs/css/buttons.css
@@ -84,4 +84,5 @@ a.downloadButton:before {
 
 .tool-label > img {
     vertical-align: middle;
+    height: 1rem;
 }

--- a/docs/guide/pdfs.md
+++ b/docs/guide/pdfs.md
@@ -1,0 +1,107 @@
+# Working With PDF Files
+
+Xournal++ supports various features for annotating on top of PDF files.
+
+The main way to interact with an external PDF file is to use the PDF file as the
+background of a journal.
+
+## Setting a PDF file as a background
+
+To create a new journal that uses a PDF file as a background, you can use the
+menu option `File > Annotate PDF` or `File > Open`. This will open a dialog that
+will allow you to select a PDF file, and then it will create a new journal with
+that PDF file as the background.
+
+!!! note
+    Xournal++ currently stores the journal file (`.xopp`) separately from the
+    PDF file. When you save a journal file, the _absolute path_ of the PDF file
+    will be stored in the `.xopp` file. This means that if you move the `.xopp`
+    file to another computer, or if you move the PDF to another location,
+    Xournal++ will not be able to find your background PDF. When this happens,
+    opening the journal file will lead to Xournal++ prompting you to either
+    identify the new location of your PDF or select a new one.
+    <br/>
+    <br/>
+    To work around this problem, you can use the [PDF attach mode](#attach-mode)
+    as described below.
+    <br/>
+    <br/>
+    There are future plans to introduce a "bundled" file format that stores the
+    journal and the PDF file in the same file. For more information, see
+    [this issue on our issue tracker](https://github.com/xournalpp/xournalpp/issues/937).
+
+### Attach mode
+
+If you use `File > Annotate PDF` to create a new journal, you can check the
+`Attach file to the journal` checkbox to enable "attach mode". When attach mode
+is enabled for a journal, the PDF file will always be copied to the same
+directory as the `.xopp` file when saving, even if the `.xopp` file is moved.
+Futhermore, the journal file will store a _relative path_ to the PDF file.
+
+Together, this means that you can savely "move" a `.xopp` file that has a PDF
+background _as long as you ensure that you "move" the file using `File > Save
+As`_!
+
+!!! bug
+    In Xournal++ 1.1.1 and older, there was a bug where attach mode settings
+        would not be remembered when loading. This bug has been fixed in Xournal++
+    1.1.2.
+
+## Navigating the PDF file
+
+If the PDF file contains a table of contents, the "Outline" tab of the sidebar
+will display the table of contents. Clicking on an entry in the "Outline" tab
+will jump the canvas to the corresponding page.
+
+## Relationship between the Journal and the PDF background
+
+Due to the way Xournal++ works, there are several limitations on modifying
+journal pages or modifying the background PDF file:
+
+* Because Xournal++ treats the background PDF file separately, changing the
+  background PDF file may cause annotations to "go out of sync" with the
+  background PDF. For example, if pages are removed from the background PDF,
+  then the journal file will still contain pages referencing the removed pages.
+  Xournal++ will not delete the annotations on those pages, but the (removed)
+  pages will no longer be rendered.
+* If pages are added to the background PDF file, Xournal++ will _not_
+  automatically insert the newly added pages. The new pages must be inserted
+  into the journal using the `Journal > Append New PDF Pages` menu option.
+
+## Searching for PDF Text
+
+To search for text contained in a PDF background page, use `Edit > Search` or
+the keyboard shortcut <kbd>Ctrl</kbd><kbd>F</kbd>. This will open a prompt that
+will allow you to search for the given text on all PDF pages.
+
+## Interacting with PDF Pages
+
+!!! note
+    This feature is only available in the nightly version.
+
+The PDF Toolbox feature can be used to interact with the background PDF pages.
+This feature is available through the following tools:
+
+* Select Linear PDF Text: select lines of text on the PDF
+* Select PDF Text in Rectangle: select text on the PDF using a rectangular
+  cursor
+
+For more information, see the [PDF Tools](tools/pdf_tools.md) page.
+
+## Exporting to PDF
+
+The journal file and its PDF background can be exported in the usual way using
+the `File > Export as PDF` menu option.
+
+Due to the way that Xournal++ deals with PDF files, there are several
+limitations on the export:
+
+* Once you export annotations to PDF format, the annotations in the PDF file
+  cannot be edited. This is because the PDF format is not designed to be edited.
+* Xournal++'s PDF export does not preserve annotations that are built-in to the
+  PDF file, such as pop-up notes and forms.
+* Xournal++ will not allow you to override the background PDF when you export.
+  This is because overriding the background PDF will cause the annotations in
+  the journal to become inconsistent with the actual contents of the (newly
+  overridden) background PDF. For a more detailed discussion of this problem,
+  see [this issue](https://github.com/xournalpp/xournalpp/issues/2363).

--- a/docs/guide/tools/pdf_tools.md
+++ b/docs/guide/tools/pdf_tools.md
@@ -1,0 +1,10 @@
+# PDF Tools
+
+The PDF tools can be used to interact with the background PDF.
+
+## PDF Toolbox
+
+!!! note
+    This feature is only available in the nightly version.
+    
+TODO: write docs explaining how to use it

--- a/docs/guide/tools/pdf_tools.md
+++ b/docs/guide/tools/pdf_tools.md
@@ -1,10 +1,45 @@
 # PDF Tools
 
+!!! note
+    This feature is only available in the nightly version.
+
 The PDF tools can be used to interact with the background PDF.
 
 ## PDF Toolbox
 
-!!! note
-    This feature is only available in the nightly version.
-    
-TODO: write docs explaining how to use it
+The PDF Toolbox provides various features for interacting with PDF pages. The
+toolbox is first activated using one of the tools described below, and then a
+popup window will show some actions that can be taken.
+
+### Selecting Text
+
+There are two tools that can be used to select text on a PDF: Select Linear PDF
+Text and Select PDF Text in Rectangle.
+
+The
+<span class="tool-label">**Select Linear PDF Text Tool** ![Select Linear PDF Text Tool icon](https://raw.githubusercontent.com/xournalpp/xournalpp/master/ui/iconsColor-light/hicolor/scalable/actions/xopp-select-pdf-text-ht.svg)</span>
+is used to select lines of text.
+
+* Click to start the selection, and drag the pen/mouse cursor to select text
+  linearly. Release to finish the selection.
+* Double tap/click to select by lines.
+* Triple tap/click to select by paragraph.
+
+The
+<span class="tool-label">**Select PDF Text in Rectangle Tool** ![Select Linear PDF Text Tool icon](https://raw.githubusercontent.com/xournalpp/xournalpp/master/ui/iconsColor-light/hicolor/scalable/actions/xopp-select-pdf-text-area.svg)</span>
+is similar, except that it creates a selection rectangle such that all text
+contained in the rectangular region will be selected. Using double/triple
+selection with this tool will default to the behavior of the linear selection
+tool.
+
+### Interacting with Selected Text
+
+Once text selection is finalized, a popup window with several actions will be
+shown.
+
+* The large button with the copy icon will copy the selected text to the clipboard.
+* The three buttons on the right side of the toolbox will create a stroke that
+  (from top to bottom, respectively): 1) highlights the selected text; 2)
+  underlines the selected text; 3) strikes through the selected text.
+* The button at the bottom left will toggle between linear selection and
+  region selection.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,10 +21,12 @@ nav:
          - Eraser tool: guide/tools/eraser.md
          - Selection and Snapping tools: guide/tools/selecsnap.md
          - LaTeX tool: guide/tools/latex.md
+         - PDF tools: guide/tools/pdf_tools.md
+      - Working With PDF Files: guide/pdfs.md
       - Plugins: 
          - Building plugins: guide/plugins/plugins.md
          - Notable plugins: guide/plugins/notable.md
-      - File locations: guide/file-locations.md
+      - File Locations: guide/file-locations.md
       - Tips: guide/tips.md
   - Community: 
       - Getting help & helping out: community/help.md


### PR DESCRIPTION
Here is some documentation I wrote on:
* Some of the features used for interacting with PDFs
* Pitfalls/subtleties when using annotating PDFs
* The new PDF toolbox and the select PDF text tools

The instructions on "Exporting to PDF" are still WIP.