### PR TITLE
Update version numbers to 1.1.2

### DIFF
--- a/docs/guide/plugins/plugins.md
+++ b/docs/guide/plugins/plugins.md
@@ -98,7 +98,7 @@ Currently the list contains the following functions:
 - `app.changeToolColor` changes the color of any tool with color capabilities
 - `app.changeCurrentPageBackground` changes the background [type](https://github.com/xournalpp/xournalpp/blob/9d1277dee22bb095c2db047bb04f89cc837aee3c/src/control/pagetype/PageTypeHandler.cpp#L98-L133) and [config](https://github.com/xournalpp/xournalpp/issues/2137#issuecomment-799956788) of the current page
 - `app.changeBackgroundPdfPageNr` changes the page number of the background PDF of the current page
-- [`app.getToolInfo`](https://github.com/xournalpp/xournalpp/commit/eb3b7eb292e51e2e5adb2741cbba669eb02a199b) returns all properties of a specific or the active tool **(only available in [nightly release][nightly-release] as of v1.1.1)**
+- [`app.getToolInfo`](https://github.com/xournalpp/xournalpp/commit/eb3b7eb292e51e2e5adb2741cbba669eb02a199b) returns all properties of a specific or the active tool **(only available in [nightly release][nightly-release] as of v1.1.2)**
 - `app.getDocumentStructure` returns lots of useful info on the document, also used for applying operations on all/selected pages
 - `app.scrollToPage` scrolls relatively or absolutely to a page
 - `app.scrollToPos` scrolls relatively or absolutely to a new position on the same page
@@ -111,15 +111,15 @@ Currently the list contains the following functions:
 - `app.scaleTextElements` scales all text elements of the current layer by the given scale factor
 - `app.getDisplayDpi` returns the configured display DPI
 - `app.export` exports the current document in pdf, svg or png format
-**(only available in [nightly release][nightly-release] as of v1.1.1)**
+**(only available in [nightly release][nightly-release] as of v1.1.2)**
 - `app.addStrokes` draws strokes on the canvas given a set of coordinates
-**(only available in [nightly release][nightly-release] as of v1.1.1)**
+**(only available in [nightly release][nightly-release] as of v1.1.2)**
 - `app.addSplines` draws strokes on the canvas given a set of splines. The function rasterizes it, then uses the resulting series of coordinates to place the stroke on the canvas
-**(only available in [nightly release][nightly-release] as of v1.1.1)**
+**(only available in [nightly release][nightly-release] as of v1.1.2)**
 - `app.getFilePath` opens a "Open File" dialogue and returns the chosen file path by the user
-**(only available in [nightly release][nightly-release] as of v1.1.1)**
+**(only available in [nightly release][nightly-release] as of v1.1.2)**
 - `app.refreshPage` notifies Xournal++ of changes done by the `addStrokes` and `addSplines` functions, causing the strokes to appear on the canvas.
-**(only available in [nightly release][nightly-release] as of v1.1.1)**
+**(only available in [nightly release][nightly-release] as of v1.1.2)**
 
 All those functions are documented in the same file [`luapi_application.h`](https://github.com/xournalpp/xournalpp/blob/7b6d84956d6bbe8615b2123c64dd0cac80afb81a/src/core/plugin/luapi_application.h), including example usage. Future progress on the Plugin API will be reported here. Help is always welcome.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,8 +62,8 @@ extra:
   version:
     # TODO: build the download links from these instead of hardcoding them in
     # overrides/installation/download-links.md
-    latest_stable: "1.1.1"
-    latest_unstable: "1.1.1+dev"
+    latest_stable: "1.1.2"
+    latest_unstable: "1.1.2+dev"
 
 #code highlighting
 markdown_extensions:

--- a/overrides/installation/download-links.md
+++ b/overrides/installation/download-links.md
@@ -3,20 +3,20 @@
 {% set nightly = "https://github.com/xournalpp/xournalpp/releases/tag/nightly" %}
 {% set windows = 
     ({
-        "stable" : "https://github.com/xournalpp/xournalpp/releases/download/v1.1.1/xournalpp-1.1.1-windows.zip"
+        "stable" : "https://github.com/xournalpp/xournalpp/releases/download/v1.1.2/xournalpp-1.1.2-windows.zip"
     })
 %}
 {% set macos = 
     ({
-        "stable" : "https://github.com/xournalpp/xournalpp/releases/download/v1.1.1/xournalpp-1.1.1-macos.zip"
+        "stable" : "https://github.com/xournalpp/xournalpp/releases/download/v1.1.2/xournalpp-1.1.2-macos.zip"
     })
 %}
 {% set linux = 
     ({
         "flatpak": "https://flathub.org/apps/details/com.github.xournalpp.xournalpp",
-        "appimage": "https://github.com/xournalpp/xournalpp/releases/download/v1.1.1/xournalpp-1.1.1-x86_64.AppImage",
+        "appimage": "https://github.com/xournalpp/xournalpp/releases/download/v1.1.2/xournalpp-1.1.2-x86_64.AppImage",
         "snap": "https://snapcraft.io/xournalpp",
-        "debianStable": "https://github.com/xournalpp/xournalpp/releases/tag/v1.1.1",
-        "ubuntuStable": "https://github.com/xournalpp/xournalpp/releases/tag/v1.1.1"
+        "debianStable": "https://github.com/xournalpp/xournalpp/releases/tag/v1.1.2",
+        "ubuntuStable": "https://github.com/xournalpp/xournalpp/releases/tag/v1.1.2"
     })
 %}


### PR DESCRIPTION
Updated all relevant version numbers. I didn't change those in `linux.md` "NixOS / Nix", since it's only an example and uses a sha256, which would become wrong when replacing 1.1.1 with 1.1.2.
