### PR TITLE
Update links after 1.2.5 release

### DIFF
--- a/docs/installation/macos.md
+++ b/docs/installation/macos.md
@@ -29,14 +29,13 @@ versions:
 1. Download the zip or dmg file.
 2. Copy the Xournal++ program contained in the zip/dmg file to the Applications
    folder.
-3. In case of the dmg file run `xattr -d com.apple.quarantine /Applications/Xournal++.app` to remove quarantine.
-4. Two-finger click (or right-click) the Xournal++ program and choose "Open"
+3. Two-finger click (or right-click) the Xournal++ program and choose "Open"
    from the menu that appears.
-5. Read the prompt and confirm that you want to open the program. If there is no
+4. Read the prompt and confirm that you want to open the program. If there is no
    button to open the program, choose "Cancel" and try again from the previous
    step. The "Open" button should appear on the second attempt.
-6. Run Xournal++ like any other program.
-7. Success!
+5. Run Xournal++ like any other program.
+6. Success!
 
 For a video demonstration of how to install Xournal++, see
 [this comment on GitHub][video-demo].

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,8 +63,8 @@ extra:
   version:
     # TODO: build the download links from these instead of hardcoding them in
     # overrides/installation/download-links.md
-    latest_stable: "1.2.4"
-    latest_unstable: "1.2.4+dev"
+    latest_stable: "1.2.5"
+    latest_unstable: "1.2.5+dev"
 
 #code highlighting
 markdown_extensions:

--- a/overrides/installation/download-links.md
+++ b/overrides/installation/download-links.md
@@ -3,21 +3,21 @@
 {% set nightly = "https://github.com/xournalpp/xournalpp/releases/tag/nightly" %}
 {% set windows =
     ({
-        "stable" : "https://github.com/xournalpp/xournalpp/releases/download/v1.2.4/xournalpp-1.2.4-windows.zip"
+        "stable" : "https://github.com/xournalpp/xournalpp/releases/download/v1.2.5/xournalpp-1.2.5-windows-setup-x86_64.exe"
     })
 %}
 {% set macos =
     ({
-        "stable" : "https://github.com/xournalpp/xournalpp/releases/download/v1.2.4/xournalpp-1.2.4-macos.zip",
-        "stable-arm" : "https://github.com/xournalpp/xournalpp/releases/download/v1.2.4/xournalpp-1.2.4-macos-arm.dmg"
+        "stable" : "https://github.com/xournalpp/xournalpp/releases/download/v1.2.5/xournalpp-1.2.5-macOS-X64.dmg",
+        "stable-arm" : "https://github.com/xournalpp/xournalpp/releases/download/v1.2.5/xournalpp-1.2.5-macOS-ARM64.dmg"
     })
 %}
 {% set linux =
     ({
         "flatpak": "https://flathub.org/apps/details/com.github.xournalpp.xournalpp",
-        "appimage": "https://github.com/xournalpp/xournalpp/releases/download/v1.2.4/xournalpp-1.2.4-x86_64.AppImage",
+        "appimage": "https://github.com/xournalpp/xournalpp/releases/download/v1.2.5/xournalpp-1.2.5-x86_64.AppImage",
         "snap": "https://snapcraft.io/xournalpp",
-        "debianStable": "https://github.com/xournalpp/xournalpp/releases/tag/v1.2.4",
-        "ubuntuStable": "https://github.com/xournalpp/xournalpp/releases/tag/v1.2.4"
+        "debianStable": "https://github.com/xournalpp/xournalpp/releases/tag/v1.2.5",
+        "ubuntuStable": "https://github.com/xournalpp/xournalpp/releases/tag/v1.2.5"
     })
 %}


### PR DESCRIPTION
The quarantine removal is not necessary any more.